### PR TITLE
PHP: Switch / match / if best practice

### DIFF
--- a/docs/php/php.md
+++ b/docs/php/php.md
@@ -2,7 +2,6 @@
 title: 'PHP'
 ---
 
-
 ## Gestion des pluriels
 
 Le nom des variables, quand elles sont au pluriels DOIVENT se terminer par `List` et NE DOIVENT PAS se terminer par `s`.
@@ -16,7 +15,7 @@ Cela permet aussi d'éviter les problèmes de complexités grammaticales en angl
 
 ## Assertions
 
-En PHP, on a plusieurs façons de faire des assertions. Pour rappel une assertions en PHP [est définie de la manière suivante](https://www.php.net/assert) : 
+En PHP, on a plusieurs façons de faire des assertions. Pour rappel une assertions en PHP [est définie de la manière suivante](https://www.php.net/assert) :
 
 :::info Assertion
 Les assertions doivent être utilisées uniquement comme fonctionnalité de débogage. Un cas d'utilisation pour les assertions est de servir de vérifications de cohérence pour des préconditions qui devraient toujours être true, et si elles ne sont pas respectées, cela indique des erreurs de programmation.
@@ -34,8 +33,7 @@ if (!is_int($id)) {
 
 C'est très fonctionnel, mais c'est un peu verbeux, et on ne sait jamais trop quelle exception lancer (`InvalidArgumentException`, `RuntimeException`, `LogicException` ?)
 
-Une autre façon est d'utiliser la fonction php [`assert`](https://www.php.net/assert) : 
-
+Une autre façon est d'utiliser la fonction php [`assert`](https://www.php.net/assert) :
 
 ```php
 assert(is_int($id));
@@ -47,6 +45,79 @@ On DEVRAIT utiliser la librairie webmozarts/assert qui donne accès à un large 
 
 :::note
 Pour info, webmozarts utilise une `InvalidArgumentException` en soute.
+:::
+
+## If / Match / Switch
+
+`If`, `match` et `switch` sont trois façons différentes d'exécuter du code conditionnel en PHP.
+Les trois façons sont valables, mais choisir l'une ou l'autre des instructions peut avoir un impact sur la lisibilité du code.
+
+On DEVRAIT utiliser `match` uniquement dans des cas "simples". Par exemple:
+
+```php
+$expressionResult = match ($condition) {
+    1, 2 => foo(),
+    3, 4 => bar(),
+    default => baz(),
+};
+
+match ($job->getName()) {
+    Job::NAME_EXPORT_DATA => $this->exportData($job),
+    Job::NAME_DENORMALIZE => $this->denormalize($job),
+    default => null,
+};
+```
+
+Dès lors que l'on veut faire plusieurs choses dans un cas, on DEVRAIT utiliser un `switch` :
+
+```php
+switch ($action) {
+    case self::NAME_EXPORT_DATA:
+        $this->exportData($job);
+        break;
+    case self::DENORMALIZE:
+        $this->publishToRabbitMQ($job);
+        $this->onJobUpdated($job);
+        $this->triggerCoffeeMachine($job);
+        break;
+    default:
+        break;
+}
+```
+
+A noter quand dans ce cas, on PEUT aussi tout à refactorer le code du `case self::DENORMALIZE` dans une méthode dédiée, et appeler `match`.
+
+Dès que les cas de tests deviennent trop complexes, on DEVRAIT utiliser un `if` / `elseif` / `else` :
+
+Par exemple, on ne DEVRAIT pas faire ça :
+
+```php
+$result = match ($x) {
+    foo() => 'value',
+    $this->bar() => 'value', // $this->bar() n'est pas appelé si foo() === $x
+    $this->baz => beep(), // beep() n'est pas appelé sauf si $x === $this->baz
+    // etc.
+};
+```
+
+Dans ce cas on DEVRAIT utiliser un `if` :
+
+```php
+if (foo()) {
+    $result = 'value';
+} elseif ($this->bar()) {
+    $result = 'value';
+} elseif ($this->baz) {
+    $result = beep();
+} else {
+    $result = null;
+}
+```
+
+:::note
+On ne DEVRAIT jamais utiliser un `match(true)` ou un `switch(true)` et TOUJOURS utiliser des `if` dans ce cas.
+
+Car le `match(true)` implique souvent que l'on va avoir des cas de tests trop complexes, sur des données différentes, et que l'on va perdre la lisibilité du code.
 :::
 
 ## Utilisation de `compact`


### PR DESCRIPTION
Ajout d'une règle de  bonne pratique concernant l'utilisation de `switch`, `match` ou `if` comme vu en point back.